### PR TITLE
Added Check for swift version

### DIFF
--- a/Sources/Style.swift
+++ b/Sources/Style.swift
@@ -26,7 +26,9 @@ public enum StyleType {
 }
 
 // workaround for https://github.com/psharanda/Atributika/issues/27
-extension NSAttributedStringKey: Hashable { }
+#if swift(>=4.1)
+	extension NSAttributedStringKey: Hashable { }
+#endif
 
 public struct Style {
     


### PR DESCRIPTION
Patch #27 works only or Xcode 9.3+ (Swift 4.1+), Added complier check to prevent warnings on Xcode 9.2/Swift 4.0